### PR TITLE
Fixes, improvements and refactoring in posts factory, PostsController, specs, Shrine etc.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,6 +65,6 @@ class PostsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def post_params
-    params.require(:post).permit(:image_data, :caption, :user_id)
+    params.require(:post).permit(:image, :caption, :user_id)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,12 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
 
-  # GET /posts or /posts.json
+  # GET /posts
   def index
     @posts = current_user.posts
   end
 
-  # GET /posts/1 or /posts/1.json
+  # GET /posts/1
   def show
   end
 
@@ -19,41 +19,29 @@ class PostsController < ApplicationController
   def edit
   end
 
-  # POST /posts or /posts.json
+  # POST /posts
   def create
     @post = current_user.posts.build(post_params)
-    respond_to do |format|
-      if @post.save
-        format.html { redirect_to user_posts_url(current_user), notice: "Post was successfully created." }
-        format.json { render :show, status: :created, location: @post }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
-      end
+    if @post.save
+      redirect_to user_posts_url(current_user), notice: "Post was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /posts/1 or /posts/1.json
+  # PATCH/PUT /posts/1
   def update
-    respond_to do |format|
-      if @post.update(post_params)
-        format.html { redirect_to user_posts_url(@post), notice: "Post was successfully updated." }
-        format.json { render :show, status: :ok, location: @post }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
-      end
+    if @post.update(post_params)
+      redirect_to user_posts_url(@post), notice: "Post was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /posts/1 or /posts/1.json
+  # DELETE /posts/1
   def destroy
     @post.destroy
-
-    respond_to do |format|
-      format.html { redirect_to user_posts_url, notice: "Post was successfully deleted." }
-      format.json { head :no_content }
-    end
+    redirect_to user_posts_url, notice: "Post was successfully deleted."
   end
 
   private

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,8 +12,8 @@
   <% end %>
 
   <div>
-    <%= form.hidden_field :image_data, value: post.cached_image_data, id: nil %>
-    <%= form.file_field :image_data %>
+    <%= form.hidden_field :image, value: post.cached_image_data, id: nil %>
+    <%= form.file_field :image %>
 
     <%= form.label :caption, style: "display: block" %>
     <%= form.text_field :caption %>

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -1,12 +1,21 @@
 require "shrine"
 require "shrine/storage/file_system"
+require "shrine/storage/memory"
 
-Shrine.storages = {
-  cache: Shrine::Storage::FileSystem.new("public", prefix: "uploads/cache"), # temporary
-  store: Shrine::Storage::FileSystem.new("public", prefix: "uploads"),       # permanent
-}
+if Rails.env.test?
+  Shrine.storages = {
+    cache: Shrine::Storage::Memory.new,
+    store: Shrine::Storage::Memory.new
+  }
+else
+  Shrine.storages = {
+    cache: Shrine::Storage::FileSystem.new("public", prefix: "uploads/cache"), # temporary
+    store: Shrine::Storage::FileSystem.new("public", prefix: "uploads"),       # permanent
+  }
+end
 
 Shrine.plugin :activerecord           # loads Active Record integration
 Shrine.plugin :cached_attachment_data # enables retaining cached file across form redisplays
 Shrine.plugin :restore_cached_data    # extracts metadata for assigned cached files
+Shrine.plugin :pretty_location
 Shrine.plugin :derivatives, create_on_promote: true

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe PostsController, type: :controller do
 
   # TODO
   describe 'POST #create' do
-    let(:post_attributes) { attributes_for(:post, user_id: user.id) }
+    let(:post_attributes) { attributes_for(:post, image: ImageUploader.new {} ) } # FIXME
     let(:request_params) do
       { user_id: user.id,
         post: post_attributes }

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe PostsController, type: :controller do
 
   # TODO
   describe 'POST #create' do
-    let(:post_attributes) { attributes_for(:post, image: ImageUploader.new {} ) } # FIXME
+    let(:post_attributes) do
+      attributes_for(:post, :simulate_form_upload)
+    end
     let(:request_params) do
       { user_id: user.id,
         post: post_attributes }

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -11,6 +11,9 @@ FactoryBot.define do
     caption { FFaker::Lorem.paragraphs.join }
 
     # Image uploaded by shrine gem (see test_data.rb)
+    image { TestData.uploaded_image }
+
+    # Image metadata
     image_data { TestData.image_data }
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -15,5 +15,10 @@ FactoryBot.define do
 
     # Image metadata
     image_data { TestData.image_data }
+
+    trait :with_real_metadata do
+      image { TestData.uploaded_image('real_metadata') }
+      image_data { TestData.image_data('real_metadata') }
+    end
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -10,15 +10,26 @@ FactoryBot.define do
     # Generates random paragraph with character length limit
     caption { FFaker::Lorem.paragraphs.join }
 
+    # Allows to choose which image version to build (default: 'valid')
+    transient do
+      version { 'valid' }
+    end
+
     # Image uploaded by shrine gem (see test_data.rb)
-    image { TestData.uploaded_image }
+    image { TestData.uploaded_image(version) }
 
     # Image metadata
-    image_data { TestData.image_data }
+    image_data { TestData.image_data(version) }
 
-    trait :with_real_metadata do
-      image { TestData.uploaded_image('real_metadata') }
-      image_data { TestData.image_data('real_metadata') }
+    # Made for controller testing. Simulates file attached and submited via html form
+    trait :simulate_form_upload do
+      image_data {}
+      image do
+        Rack::Test::UploadedFile.new(
+          Rails.root.join('spec', 'support', 'images', 'sample_1280x720.jpg'),
+          'image/jpeg'
+        )
+      end
     end
   end
 end

--- a/spec/factories/test_data.rb
+++ b/spec/factories/test_data.rb
@@ -20,6 +20,8 @@ module TestData
     file = File.open('spec/support/images/sample_1280x720.jpg', binmode: true)
 
     # Metadata to assign depending on requested file version
+    extract_real_metadata = version == 'real_metadata'
+
     common_data = {
       'size' => File.size(file.path),
       'mime_type' => 'image/jpeg',
@@ -39,8 +41,8 @@ module TestData
     }
 
     # For performance we skip metadata extraction and assign test metadata
-    uploaded_file = Shrine.upload(file, :store, metadata: false)
-    uploaded_file.metadata.merge!(data_versions[version])
+    uploaded_file = Shrine.upload(file, :store, metadata: extract_real_metadata)
+    uploaded_file.metadata.merge!(data_versions[version]) unless extract_real_metadata
     uploaded_file
   end
 end

--- a/spec/factories/test_data.rb
+++ b/spec/factories/test_data.rb
@@ -8,7 +8,7 @@ module TestData
     attacher = Shrine::Attacher.new
     attacher.set(uploaded_image(version))
 
-    # For derivatives processing
+    # Assign derivatives explicitly, to skip image processing
     attacher.set_derivatives(
       post_size: uploaded_image(version)
     )
@@ -24,8 +24,8 @@ module TestData
       'size' => File.size(file.path),
       'mime_type' => 'image/jpeg',
       'filename' => 'test.jpg',
-      'width' => 500,
-      'height' => 500
+      'width' => 1280,
+      'height' => 720
     }
 
     data_versions = {

--- a/spec/factories/test_data.rb
+++ b/spec/factories/test_data.rb
@@ -20,7 +20,7 @@ module TestData
     file = File.open('spec/support/images/sample_1280x720.jpg', binmode: true)
 
     # Metadata to assign depending on requested file version
-    extract_real_metadata = version == 'real_metadata'
+    extract_real_metadata = version == 'real_metadata' # TODO: delete these key and var if no usecases (here and lower)
 
     common_data = {
       'size' => File.size(file.path),

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Post, type: :model do
 
   describe 'association' do
     it { is_expected.to belong_to(:user) }
-    it 'has valid image with data and post_size version' do
+    it 'has valid image with data and post_size derivative version' do
+      subject.save
       expect(subject.image).to be_kind_of(ImageUploader::UploadedFile)
       expect(subject.image(:post_size)).to be_kind_of(ImageUploader::UploadedFile)
     end

--- a/spec/support/shrine.rb
+++ b/spec/support/shrine.rb
@@ -1,6 +1,8 @@
-# TODO: https://shrinerb.com/docs/testing !
-#       https://raghu-bhupatiraju.dev/shrine-testing-in-rspec-f33ff7f03497
-#       https://gist.github.com/jovanmaric/34532f425d8c2696119fb3d3a09c9e87
+# Reference docs and examples: 
+#   https://shrinerb.com/docs/testing !
+#   https://raghu-bhupatiraju.dev/shrine-testing-in-rspec-f33ff7f03497
+#   https://gist.github.com/jovanmaric/34532f425d8c2696119fb3d3a09c9e87
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = false
 end

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ImageUploader do
     end
 
     context 'too large (size-vise) file' do
-      let(:post) { create(:post, image: TestData.uploaded_image('invalid_size_large')) }
+      let(:post) { create(:post, version: 'invalid_size_large') }
 
       it 'raises error' do
         expect { post.save }.to raise_error(ActiveRecord::RecordInvalid,
@@ -31,7 +31,7 @@ RSpec.describe ImageUploader do
     end
 
     context 'too small (size-vise) file' do
-      let(:post) { create(:post, image: TestData.uploaded_image('invalid_size_small')) }
+      let(:post) { create(:post, version: 'invalid_size_small') }
 
       it 'raises error' do
         expect { post.save }.to raise_error(ActiveRecord::RecordInvalid,
@@ -40,7 +40,7 @@ RSpec.describe ImageUploader do
     end
 
     context 'wrong mime (non-image file under image extension)' do
-      let(:post) { create(:post, image: TestData.uploaded_image('invalid_mime')) }
+      let(:post) { create(:post, version: 'invalid_mime') }
 
       it 'raises error' do
         expect { post.save }.to raise_error(ActiveRecord::RecordInvalid,
@@ -49,7 +49,7 @@ RSpec.describe ImageUploader do
     end
 
     context 'wrong file extension' do
-      let(:post) { create(:post, image: TestData.uploaded_image('invalid_extention')) }
+      let(:post) { create(:post, version: 'invalid_extention') }
 
       it 'raises error' do
         expect { post.save }.to raise_error(ActiveRecord::RecordInvalid,
@@ -58,7 +58,7 @@ RSpec.describe ImageUploader do
     end
 
     context 'too wide image' do
-      let(:post) { create(:post, image: TestData.uploaded_image('invalid_width')) }
+      let(:post) { create(:post, version: 'invalid_width') }
 
       it 'raises error' do
         expect { post.save }.to raise_error(ActiveRecord::RecordInvalid,
@@ -67,7 +67,7 @@ RSpec.describe ImageUploader do
     end
 
     context 'too high image' do
-      let(:post) { create(:post, image: TestData.uploaded_image('invalid_hight')) }
+      let(:post) { create(:post, version: 'invalid_hight') }
 
       it 'raises error' do
         expect { post.save }.to raise_error(ActiveRecord::RecordInvalid,
@@ -78,14 +78,14 @@ RSpec.describe ImageUploader do
 
   describe 'derivative' do
     context 'before saving sample image to storage (promoting image, storing post instance in db`s row)' do
-      let(:post) { build(:post, image: TestData.uploaded_image) }
-      it 'is nil' do
+      let(:post) { build(:post) }
+      it 'derivatives are nil' do
         expect(derivatives[:post_size]).to be_nil
       end
     end
 
     context 'after saving 1920x1280 image to storage (promoting)' do
-      let(:post) { create(:post, image: File.open('spec/support/images/sample_1920x1280.jpg', 'rb'))}
+      let(:post) { create(:post, image: File.open('spec/support/images/sample_1920x1280.jpg', 'rb'), image_data: {}) }
 
       it 'generates derivative image' do
         expect(derivatives[:post_size]).to be_kind_of(Shrine::UploadedFile)
@@ -100,7 +100,7 @@ RSpec.describe ImageUploader do
     end
 
     context 'after saving 427x640 image to storage (promoting)' do
-      let(:post) { create(:post, image: File.open('spec/support/images/sample_427x640.jpg', 'rb'))}
+      let(:post) { create(:post, image: File.open('spec/support/images/sample_427x640.jpg', 'rb'), image_data: {}) }
 
       it 'upscales to fit 1080x1080' do
         expect(image.width).to  be < derivatives[:post_size].width


### PR DESCRIPTION
### In Shrine config:
- **Fixed bug of cluttered file storage: it kept storing files which were created during runs of spec examples. Now it uses memory while in test environment.**
- Added pretty_location plugin

### In `PostsController`:
- Removed JSON response formats. No need in them at current app development stage and given tasks
- **Reverted fix of `PostsController#post_params` made in the commit 66a4bfc**, now it again permits `:image` which receives _file_ from HTML form submission (not metadata in `image_data`, which then is being assigned within Shrine's `ImageUploader`)

### In `factory/posts.rb`:
- Added `image` attribute, which was missing previously
- **Added trait for simulating image file attachment via html form to have valid metadata headers and values**
- Added transient `version` attribute to pass it from builder to `TestData` module and get different versions of image file
- Refactored `TestData`  module methods calls

### In `TestData` module
- Added option to not skip extraction of real metadata when generating valid uploaded image for posts factory
- Minor fix: uploaded image dimension preset values

### In spec for `PostsController#create` :
- **Fixed POST request's params to work properly, refactored call for posts factory**
- Made example "it creates a new post record with valid attributes" to pass successfully

### In spec for `ImageUploader` (Shrine):
- Refactored `TestData` module methods calls for various image file versions passing version parameter

And some other minor fixes
